### PR TITLE
ci: :construction_worker: Make ruff run on every push and pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,6 @@ name: Lint
 on:
   pull_request:
   push:
-    branches: [ main ]
 
 jobs:
   lint:


### PR DESCRIPTION
Should stop errors about linting when pushing